### PR TITLE
Add cluster "placeholder" entity

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -195,6 +195,7 @@ The following entities are created:
 
 | Resources              | Entity `_type`      | Entity `_class` |
 | ---------------------- | ------------------- | --------------- |
+| Kubernetes Cluster     | `kube_cluster`      | `Cluster`       |
 | Kubernetes ConfigMap   | `kube_config_map`   | `Configuration` |
 | Kubernetes CronJob     | `kube_cron_job`     | `Task`          |
 | Kubernetes DaemonSet   | `kube_daemon_set`   | `Deployment`    |

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -57,6 +57,9 @@ export default async function getStepStartStates(
     ]);
 
     return {
+      [IntegrationSteps.CLUSTERS]: {
+        disabled: false,
+      },
       [IntegrationSteps.NAMESPACES]: {
         disabled: false,
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { IntegrationConfig, instanceConfigFields } from './config';
 import { validateInvocation } from './validator';
 import { IntegrationInvocationConfig } from '@jupiterone/integration-sdk-core';
+import { clustersSteps } from './steps/clusters';
 import { namespaceSteps } from './steps/namespaces';
 import { nodeSteps } from './steps/nodes';
 import { serviceSteps } from './steps/services';
@@ -15,22 +16,22 @@ import { secretsSteps } from './steps/secrets';
 
 import getStepStartStates from './getStepStartStates';
 
-export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> =
-  {
-    instanceConfigFields,
-    validateInvocation,
-    getStepStartStates,
-    integrationSteps: [
-      ...namespaceSteps,
-      ...nodeSteps,
-      ...serviceSteps,
-      ...deploymentsSteps,
-      ...replicaSetsSteps,
-      ...statefulSetsSteps,
-      ...daemonSetsSteps,
-      ...jobsSteps,
-      ...cronJobsSteps,
-      ...configMapsSteps,
-      ...secretsSteps,
-    ],
-  };
+export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = {
+  instanceConfigFields,
+  validateInvocation,
+  getStepStartStates,
+  integrationSteps: [
+    ...clustersSteps,
+    ...namespaceSteps,
+    ...nodeSteps,
+    ...serviceSteps,
+    ...deploymentsSteps,
+    ...replicaSetsSteps,
+    ...statefulSetsSteps,
+    ...daemonSetsSteps,
+    ...jobsSteps,
+    ...cronJobsSteps,
+    ...configMapsSteps,
+    ...secretsSteps,
+  ],
+};

--- a/src/steps/clusters/__snapshots__/converters.test.ts.snap
+++ b/src/steps/clusters/__snapshots__/converters.test.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`#createClusterEntity should convert data 1`] = `
+Object {
+  "_class": Array [
+    "Cluster",
+  ],
+  "_key": "kube_cluster:example-integration",
+  "_rawData": Array [
+    Object {
+      "name": "default",
+      "rawData": Object {
+        "name": "example integration",
+      },
+    },
+  ],
+  "_type": "kube_cluster",
+  "createdOn": undefined,
+  "displayName": "example integration",
+  "name": "example integration",
+}
+`;

--- a/src/steps/clusters/__snapshots__/index.test.ts.snap
+++ b/src/steps/clusters/__snapshots__/index.test.ts.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`#fetchClusterDetails should collect data: jobState 1`] = `
+Object {
+  "collectedEntities": Array [
+    Object {
+      "_class": Array [
+        "Cluster",
+      ],
+      "_key": "kube_cluster:local-integration-instance",
+      "_rawData": Array [
+        Object {
+          "name": "default",
+          "rawData": Object {
+            "name": "Local Integration",
+          },
+        },
+      ],
+      "_type": "kube_cluster",
+      "createdOn": undefined,
+      "displayName": "Local Integration",
+      "name": "Local Integration",
+    },
+  ],
+  "collectedRelationships": Array [],
+  "encounteredTypes": Array [
+    "kube_cluster",
+  ],
+  "numCollectedEntities": 1,
+  "numCollectedRelationships": 0,
+}
+`;

--- a/src/steps/clusters/converters.test.ts
+++ b/src/steps/clusters/converters.test.ts
@@ -1,0 +1,11 @@
+import { createClusterEntity } from './converters';
+
+describe('#createClusterEntity', () => {
+  test('should convert data', () => {
+    const mockInstanceName = 'example integration';
+    const mockInstanceId = 'example-integration';
+    expect(
+      createClusterEntity(mockInstanceName, mockInstanceId),
+    ).toMatchSnapshot();
+  });
+});

--- a/src/steps/clusters/converters.ts
+++ b/src/steps/clusters/converters.ts
@@ -1,0 +1,23 @@
+import { createIntegrationEntity } from '@jupiterone/integration-sdk-core';
+import { Entities } from '../constants';
+
+function getClusterKey(id: string) {
+  return `kube_cluster:${id}`;
+}
+
+export function createClusterEntity(name: string, id: string) {
+  return createIntegrationEntity({
+    entityData: {
+      source: {
+        name,
+      },
+      assign: {
+        _class: Entities.CLUSTER._class,
+        _type: Entities.CLUSTER._type,
+        _key: getClusterKey(id),
+        name: name,
+        displayName: name,
+      },
+    },
+  });
+}

--- a/src/steps/clusters/index.test.ts
+++ b/src/steps/clusters/index.test.ts
@@ -1,0 +1,35 @@
+import { fetchClusterDetails } from '.';
+import { createDataCollectionTest } from '../../../test/recording';
+import { integrationConfig } from '../../../test/config';
+import { Entities } from '../constants';
+
+describe('#fetchClusterDetails', () => {
+  test('should collect data', async () => {
+    await createDataCollectionTest({
+      recordingName: 'fetchClusterDetails',
+      recordingDirectory: __dirname,
+      integrationConfig,
+      stepFunctions: [fetchClusterDetails],
+      entitySchemaMatchers: [
+        {
+          _type: Entities.CLUSTER._type,
+          matcher: {
+            _class: ['Cluster'],
+            schema: {
+              additionalProperties: false,
+              properties: {
+                _type: { const: 'kube_cluster' },
+                _rawData: {
+                  type: 'array',
+                  items: { type: 'object' },
+                },
+                name: { type: 'string' },
+                displayName: { type: 'string' },
+              },
+            },
+          },
+        },
+      ],
+    });
+  });
+});

--- a/src/steps/clusters/index.ts
+++ b/src/steps/clusters/index.ts
@@ -1,0 +1,31 @@
+import { IntegrationStep } from '@jupiterone/integration-sdk-core';
+import { IntegrationConfig, IntegrationStepContext } from '../../config';
+import {
+  CLUSTER_ENTITY_DATA_KEY,
+  Entities,
+  IntegrationSteps,
+} from '../constants';
+import { createClusterEntity } from './converters';
+
+export async function fetchClusterDetails(
+  context: IntegrationStepContext,
+): Promise<void> {
+  const { instance, jobState } = context;
+  const { name, id } = instance;
+
+  const clusterEntity = createClusterEntity(name, id);
+
+  await jobState.addEntity(clusterEntity);
+  await jobState.setData(CLUSTER_ENTITY_DATA_KEY, clusterEntity);
+}
+
+export const clustersSteps: IntegrationStep<IntegrationConfig>[] = [
+  {
+    id: IntegrationSteps.CLUSTERS,
+    name: 'Fetch Clusters',
+    entities: [Entities.CLUSTER],
+    relationships: [],
+    dependsOn: [],
+    executionHandler: fetchClusterDetails,
+  },
+];

--- a/src/steps/constants.ts
+++ b/src/steps/constants.ts
@@ -4,7 +4,10 @@ import {
   StepRelationshipMetadata,
 } from '@jupiterone/integration-sdk-core';
 
+export const CLUSTER_ENTITY_DATA_KEY = 'entity:cluster';
+
 export enum IntegrationSteps {
+  CLUSTERS = 'fetch-clusters',
   NAMESPACES = 'fetch-namespaces',
   NODES = 'fetch-nodes',
   SERVICES = 'fetch-services',
@@ -20,6 +23,7 @@ export enum IntegrationSteps {
 }
 
 export const Entities: Record<
+  | 'CLUSTER'
   | 'NAMESPACE'
   | 'NODE'
   | 'SERVICE'
@@ -35,6 +39,11 @@ export const Entities: Record<
   | 'CONTAINER',
   StepEntityMetadata
 > = {
+  CLUSTER: {
+    _type: 'kube_cluster',
+    _class: ['Cluster'],
+    resourceName: 'Kubernetes Cluster',
+  },
   NAMESPACE: {
     _type: 'kube_namespace',
     _class: ['Group'],


### PR DESCRIPTION
This adds a cluster entity that'll act as a bridge between the cloud provider’s entity, and the core cluster resources. Mostly just as a placeholder for now.

@austinkelleher 