### PR TITLE
Add pod security policies CIS benchmarks

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -193,38 +193,40 @@ https://github.com/JupiterOne/sdk/blob/main/docs/integrations/development.md
 
 The following entities are created:
 
-| Resources              | Entity `_type`      | Entity `_class` |
-| ---------------------- | ------------------- | --------------- |
-| Kubernetes Cluster     | `kube_cluster`      | `Cluster`       |
-| Kubernetes ConfigMap   | `kube_config_map`   | `Configuration` |
-| Kubernetes CronJob     | `kube_cron_job`     | `Task`          |
-| Kubernetes DaemonSet   | `kube_daemon_set`   | `Deployment`    |
-| Kubernetes Deployment  | `kube_deployment`   | `Deployment`    |
-| Kubernetes Job         | `kube_job`          | `Task`          |
-| Kubernetes Namespace   | `kube_namespace`    | `Group`         |
-| Kubernetes Node        | `kube_node`         | `Host`          |
-| Kubernetes ReplicaSet  | `kube_replica_set`  | `Deployment`    |
-| Kubernetes Secret      | `kube_secret`       | `Vault`         |
-| Kubernetes Service     | `kube_service`      | `Service`       |
-| Kubernetes StatefulSet | `kube_stateful_set` | `Deployment`    |
+| Resources                      | Entity `_type`             | Entity `_class` |
+| ------------------------------ | -------------------------- | --------------- |
+| Kubernetes Cluster             | `kube_cluster`             | `Cluster`       |
+| Kubernetes ConfigMap           | `kube_config_map`          | `Configuration` |
+| Kubernetes CronJob             | `kube_cron_job`            | `Task`          |
+| Kubernetes DaemonSet           | `kube_daemon_set`          | `Deployment`    |
+| Kubernetes Deployment          | `kube_deployment`          | `Deployment`    |
+| Kubernetes Job                 | `kube_job`                 | `Task`          |
+| Kubernetes Namespace           | `kube_namespace`           | `Group`         |
+| Kubernetes Node                | `kube_node`                | `Host`          |
+| Kubernetes Pod Security Policy | `kube_pod_security_policy` | `Configuration` |
+| Kubernetes ReplicaSet          | `kube_replica_set`         | `Deployment`    |
+| Kubernetes Secret              | `kube_secret`              | `Vault`         |
+| Kubernetes Service             | `kube_service`             | `Service`       |
+| Kubernetes StatefulSet         | `kube_stateful_set`        | `Deployment`    |
 
 ### Relationships
 
 The following relationships are created/mapped:
 
-| Source Entity `_type` | Relationship `_class` | Target Entity `_type` |
-| --------------------- | --------------------- | --------------------- |
-| `kube_cron_job`       | **MANAGES**           | `kube_job`            |
-| `kube_deployment`     | **MANAGES**           | `kube_replica_set`    |
-| `kube_namespace`      | **CONTAINS**          | `kube_config_map`     |
-| `kube_namespace`      | **CONTAINS**          | `kube_cron_job`       |
-| `kube_namespace`      | **CONTAINS**          | `kube_daemon_set`     |
-| `kube_namespace`      | **CONTAINS**          | `kube_deployment`     |
-| `kube_namespace`      | **CONTAINS**          | `kube_job`            |
-| `kube_namespace`      | **CONTAINS**          | `kube_replica_set`    |
-| `kube_namespace`      | **CONTAINS**          | `kube_secret`         |
-| `kube_namespace`      | **CONTAINS**          | `kube_service`        |
-| `kube_namespace`      | **CONTAINS**          | `kube_stateful_set`   |
+| Source Entity `_type` | Relationship `_class` | Target Entity `_type`      |
+| --------------------- | --------------------- | -------------------------- |
+| `kube_cluster`        | **CONTAINS**          | `kube_pod_security_policy` |
+| `kube_cron_job`       | **MANAGES**           | `kube_job`                 |
+| `kube_deployment`     | **MANAGES**           | `kube_replica_set`         |
+| `kube_namespace`      | **CONTAINS**          | `kube_config_map`          |
+| `kube_namespace`      | **CONTAINS**          | `kube_cron_job`            |
+| `kube_namespace`      | **CONTAINS**          | `kube_daemon_set`          |
+| `kube_namespace`      | **CONTAINS**          | `kube_deployment`          |
+| `kube_namespace`      | **CONTAINS**          | `kube_job`                 |
+| `kube_namespace`      | **CONTAINS**          | `kube_replica_set`         |
+| `kube_namespace`      | **CONTAINS**          | `kube_secret`              |
+| `kube_namespace`      | **CONTAINS**          | `kube_service`             |
+| `kube_namespace`      | **CONTAINS**          | `kube_stateful_set`        |
 
 <!--
 ********************************************************************************

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -57,6 +57,9 @@ export default async function getStepStartStates(
     ]);
 
     return {
+      [IntegrationSteps.POD_SECURITY_POLICIES]: {
+        disabled: false,
+      },
       [IntegrationSteps.CLUSTERS]: {
         disabled: false,
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { jobsSteps } from './steps/jobs';
 import { cronJobsSteps } from './steps/cron-jobs';
 import { configMapsSteps } from './steps/config-maps';
 import { secretsSteps } from './steps/secrets';
+import { policiesSteps } from './steps/policies';
 
 import getStepStartStates from './getStepStartStates';
 
@@ -21,6 +22,7 @@ export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = 
   validateInvocation,
   getStepStartStates,
   integrationSteps: [
+    ...policiesSteps,
     ...clustersSteps,
     ...namespaceSteps,
     ...nodeSteps,

--- a/src/kubernetes/clients/policy.ts
+++ b/src/kubernetes/clients/policy.ts
@@ -1,0 +1,37 @@
+import * as k8s from '@kubernetes/client-node';
+import { V1beta1PodSecurityPolicyList } from '@kubernetes/client-node';
+import { IntegrationConfig } from '../../config';
+import { Client } from '../client';
+
+export class PolicyClient extends Client {
+  private client: k8s.PolicyV1beta1Api;
+
+  constructor(config: IntegrationConfig) {
+    super(config);
+
+    this.authenticate();
+    this.client = this.kubeConfig.makeApiClient(k8s.PolicyV1beta1Api);
+  }
+
+  async iteratePodSecurityPolicies(
+    callback: (data: k8s.V1beta1PodSecurityPolicy) => Promise<void>,
+  ) {
+    await this.iterateApi(
+      async (nextPageToken) => {
+        return this.client.listPodSecurityPolicy(
+          undefined,
+          undefined,
+          nextPageToken,
+          undefined,
+          undefined,
+          this.maxPerPage,
+        );
+      },
+      async (data: V1beta1PodSecurityPolicyList) => {
+        for (const item of data.items || []) {
+          await callback(item);
+        }
+      },
+    );
+  }
+}

--- a/src/steps/constants.ts
+++ b/src/steps/constants.ts
@@ -7,6 +7,7 @@ import {
 export const CLUSTER_ENTITY_DATA_KEY = 'entity:cluster';
 
 export enum IntegrationSteps {
+  POD_SECURITY_POLICIES = 'fetch-pod-security-policies',
   CLUSTERS = 'fetch-clusters',
   NAMESPACES = 'fetch-namespaces',
   NODES = 'fetch-nodes',
@@ -23,6 +24,7 @@ export enum IntegrationSteps {
 }
 
 export const Entities: Record<
+  | 'POD_SECURITY_POLICY'
   | 'CLUSTER'
   | 'NAMESPACE'
   | 'NODE'
@@ -39,6 +41,11 @@ export const Entities: Record<
   | 'CONTAINER',
   StepEntityMetadata
 > = {
+  POD_SECURITY_POLICY: {
+    _type: 'kube_pod_security_policy',
+    _class: ['Configuration'],
+    resourceName: 'Kubernetes Pod Security Policy',
+  },
   CLUSTER: {
     _type: 'kube_cluster',
     _class: ['Cluster'],
@@ -112,6 +119,7 @@ export const Entities: Record<
 };
 
 export const Relationships: Record<
+  | 'CLUSTER_CONTAINS_POD_SECURITY_POLICY'
   | 'NAMESPACE_CONTAINS_POD'
   | 'NAMESPACE_CONTAINS_SERVICE'
   | 'NAMESPACE_CONTAINS_DEPLOYMENT'
@@ -131,6 +139,12 @@ export const Relationships: Record<
   | 'POD_CONTAINS_CONTAINER',
   StepRelationshipMetadata
 > = {
+  CLUSTER_CONTAINS_POD_SECURITY_POLICY: {
+    _type: 'kube_cluster_contains_pod_security_policy',
+    _class: RelationshipClass.CONTAINS,
+    sourceType: Entities.CLUSTER._type,
+    targetType: Entities.POD_SECURITY_POLICY._type,
+  },
   NAMESPACE_CONTAINS_POD: {
     _type: 'kube_namespace_contains_pod',
     _class: RelationshipClass.CONTAINS,

--- a/src/steps/policies/__recordings__/fetchPodSecurityPolicies_3421991598/recording.har
+++ b/src/steps/policies/__recordings__/fetchPodSecurityPolicies_3421991598/recording.har
@@ -1,0 +1,98 @@
+{
+  "log": {
+    "_recordingName": "fetchPodSecurityPolicies",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "53298badcab817b03148571c8880eb3b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "host",
+              "value": "192.168.49.2:8443"
+            }
+          ],
+          "headersSize": 142,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "limit",
+              "value": "50"
+            }
+          ],
+          "url": "https://192.168.49.2:8443/apis/policy/v1beta1/podsecuritypolicies?limit=50"
+        },
+        "response": {
+          "bodySize": 1389,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1389,
+            "text": "{\"kind\":\"PodSecurityPolicyList\",\"apiVersion\":\"policy/v1beta1\",\"metadata\":{\"resourceVersion\":\"1214963\"},\"items\":[{\"metadata\":{\"name\":\"example\",\"uid\":\"d2ddbbb0-5714-4597-bc8b-cc521a978870\",\"resourceVersion\":\"1214124\",\"creationTimestamp\":\"2021-11-01T17:48:24Z\",\"annotations\":{\"kubectl.kubernetes.io/last-applied-configuration\":\"{\\\"apiVersion\\\":\\\"policy/v1beta1\\\",\\\"kind\\\":\\\"PodSecurityPolicy\\\",\\\"metadata\\\":{\\\"annotations\\\":{},\\\"name\\\":\\\"example\\\"},\\\"spec\\\":{\\\"fsGroup\\\":{\\\"rule\\\":\\\"RunAsAny\\\"},\\\"privileged\\\":false,\\\"runAsUser\\\":{\\\"rule\\\":\\\"RunAsAny\\\"},\\\"seLinux\\\":{\\\"rule\\\":\\\"RunAsAny\\\"},\\\"supplementalGroups\\\":{\\\"ranges\\\":[{\\\"max\\\":65535,\\\"min\\\":1}],\\\"rule\\\":\\\"MustRunAs\\\"},\\\"volumes\\\":[\\\"*\\\"]}}\\n\"},\"managedFields\":[{\"manager\":\"kubectl-client-side-apply\",\"operation\":\"Update\",\"apiVersion\":\"policy/v1beta1\",\"time\":\"2021-11-01T18:27:53Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:metadata\":{\"f:annotations\":{\".\":{},\"f:kubectl.kubernetes.io/last-applied-configuration\":{}}},\"f:spec\":{\"f:allowPrivilegeEscalation\":{},\"f:fsGroup\":{\"f:rule\":{}},\"f:runAsUser\":{\"f:rule\":{}},\"f:seLinux\":{\"f:rule\":{}},\"f:supplementalGroups\":{\"f:ranges\":{},\"f:rule\":{}},\"f:volumes\":{}}}}]},\"spec\":{\"volumes\":[\"*\"],\"seLinux\":{\"rule\":\"RunAsAny\"},\"runAsUser\":{\"rule\":\"RunAsAny\"},\"supplementalGroups\":{\"rule\":\"MustRunAs\",\"ranges\":[{\"min\":1,\"max\":65535}]},\"fsGroup\":{\"rule\":\"RunAsAny\"},\"allowPrivilegeEscalation\":true}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache, private"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "x-kubernetes-pf-flowschema-uid",
+              "value": "210417ef-0504-45ee-ba4b-365d19207515"
+            },
+            {
+              "name": "x-kubernetes-pf-prioritylevel-uid",
+              "value": "f6528105-041a-490a-9dfb-a86e0c629d2a"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 01 Nov 2021 18:47:36 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1389"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 289,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-11-01T18:47:36.737Z",
+        "time": 28,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 28
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/policies/__snapshots__/index.test.ts.snap
+++ b/src/steps/policies/__snapshots__/index.test.ts.snap
@@ -1,0 +1,192 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`#fetchPodSecurityPolicies should collect data: jobState 1`] = `
+Object {
+  "collectedEntities": Array [
+    Object {
+      "_class": Array [
+        "Cluster",
+      ],
+      "_key": "kube_cluster:local-integration-instance",
+      "_rawData": Array [
+        Object {
+          "name": "default",
+          "rawData": Object {
+            "name": "Local Integration",
+          },
+        },
+      ],
+      "_type": "kube_cluster",
+      "createdOn": undefined,
+      "displayName": "Local Integration",
+      "name": "Local Integration",
+    },
+    Object {
+      "_class": Array [
+        "Configuration",
+      ],
+      "_key": "d2ddbbb0-5714-4597-bc8b-cc521a978870",
+      "_rawData": Array [
+        Object {
+          "name": "default",
+          "rawData": V1beta1PodSecurityPolicy {
+            "apiVersion": undefined,
+            "kind": undefined,
+            "metadata": V1ObjectMeta {
+              "annotations": Object {
+                "kubectl.kubernetes.io/last-applied-configuration": "{\\"apiVersion\\":\\"policy/v1beta1\\",\\"kind\\":\\"PodSecurityPolicy\\",\\"metadata\\":{\\"annotations\\":{},\\"name\\":\\"example\\"},\\"spec\\":{\\"fsGroup\\":{\\"rule\\":\\"RunAsAny\\"},\\"privileged\\":false,\\"runAsUser\\":{\\"rule\\":\\"RunAsAny\\"},\\"seLinux\\":{\\"rule\\":\\"RunAsAny\\"},\\"supplementalGroups\\":{\\"ranges\\":[{\\"max\\":65535,\\"min\\":1}],\\"rule\\":\\"MustRunAs\\"},\\"volumes\\":[\\"*\\"]}}
+",
+              },
+              "clusterName": undefined,
+              "creationTimestamp": 2021-11-01T17:48:24.000Z,
+              "deletionGracePeriodSeconds": undefined,
+              "deletionTimestamp": undefined,
+              "finalizers": undefined,
+              "generateName": undefined,
+              "generation": undefined,
+              "labels": undefined,
+              "managedFields": Array [
+                V1ManagedFieldsEntry {
+                  "apiVersion": "policy/v1beta1",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": Object {
+                    "f:metadata": Object {
+                      "f:annotations": Object {
+                        ".": Object {},
+                        "f:kubectl.kubernetes.io/last-applied-configuration": Object {},
+                      },
+                    },
+                    "f:spec": Object {
+                      "f:allowPrivilegeEscalation": Object {},
+                      "f:fsGroup": Object {
+                        "f:rule": Object {},
+                      },
+                      "f:runAsUser": Object {
+                        "f:rule": Object {},
+                      },
+                      "f:seLinux": Object {
+                        "f:rule": Object {},
+                      },
+                      "f:supplementalGroups": Object {
+                        "f:ranges": Object {},
+                        "f:rule": Object {},
+                      },
+                      "f:volumes": Object {},
+                    },
+                  },
+                  "manager": "kubectl-client-side-apply",
+                  "operation": "Update",
+                  "time": 2021-11-01T18:27:53.000Z,
+                },
+              ],
+              "name": "example",
+              "namespace": undefined,
+              "ownerReferences": undefined,
+              "resourceVersion": "1214124",
+              "selfLink": undefined,
+              "uid": "d2ddbbb0-5714-4597-bc8b-cc521a978870",
+            },
+            "spec": V1beta1PodSecurityPolicySpec {
+              "allowPrivilegeEscalation": true,
+              "allowedCSIDrivers": undefined,
+              "allowedCapabilities": undefined,
+              "allowedFlexVolumes": undefined,
+              "allowedHostPaths": undefined,
+              "allowedProcMountTypes": undefined,
+              "allowedUnsafeSysctls": undefined,
+              "defaultAddCapabilities": undefined,
+              "defaultAllowPrivilegeEscalation": undefined,
+              "forbiddenSysctls": undefined,
+              "fsGroup": V1beta1FSGroupStrategyOptions {
+                "ranges": undefined,
+                "rule": "RunAsAny",
+              },
+              "hostIPC": undefined,
+              "hostNetwork": undefined,
+              "hostPID": undefined,
+              "hostPorts": undefined,
+              "privileged": undefined,
+              "readOnlyRootFilesystem": undefined,
+              "requiredDropCapabilities": undefined,
+              "runAsGroup": undefined,
+              "runAsUser": V1beta1RunAsUserStrategyOptions {
+                "ranges": undefined,
+                "rule": "RunAsAny",
+              },
+              "runtimeClass": undefined,
+              "seLinux": V1beta1SELinuxStrategyOptions {
+                "rule": "RunAsAny",
+                "seLinuxOptions": undefined,
+              },
+              "supplementalGroups": V1beta1SupplementalGroupsStrategyOptions {
+                "ranges": Array [
+                  V1beta1IDRange {
+                    "max": 65535,
+                    "min": 1,
+                  },
+                ],
+                "rule": "MustRunAs",
+              },
+              "volumes": Array [
+                "*",
+              ],
+            },
+          },
+        },
+      ],
+      "_type": "kube_pod_security_policy",
+      "allowPrivilegeEscalation": true,
+      "allowedCapabilities": undefined,
+      "allowedProcMountTypes": undefined,
+      "allowedUnsafeSysctls": undefined,
+      "createdOn": 1635788904000,
+      "defaultAddCapabilities": undefined,
+      "defaultAllowPrivilegeEscalation": undefined,
+      "deletionGracePeriodSeconds": undefined,
+      "displayName": "example",
+      "forbiddenSysctls": undefined,
+      "generation": undefined,
+      "hostIPC": false,
+      "hostNetwork": false,
+      "hostPID": false,
+      "name": "example",
+      "privileged": false,
+      "readOnlyRootFilesystem": false,
+      "requiredDropCapabilities": undefined,
+      "resourceVersion": "1214124",
+      "runAsGroup.range": undefined,
+      "runAsGroup.rule": undefined,
+      "runAsUser.range": undefined,
+      "runAsUser.rule": "RunAsAny",
+      "runtimeClass.allowedRuntimeClassNames": undefined,
+      "runtimeClass.defaultRuntimeClassName": undefined,
+      "seLinux.rule": "RunAsAny",
+      "seLinux.seLinuxOptions.level": undefined,
+      "seLinux.seLinuxOptions.role": undefined,
+      "seLinux.seLinuxOptions.type": undefined,
+      "seLinux.seLinuxOptions.user": undefined,
+      "supplementalGroups.range": Array [
+        "1, 65535",
+      ],
+      "supplementalGroups.rule": "MustRunAs",
+    },
+  ],
+  "collectedRelationships": Array [
+    Object {
+      "_class": "CONTAINS",
+      "_fromEntityKey": "kube_cluster:local-integration-instance",
+      "_key": "kube_cluster:local-integration-instance|contains|d2ddbbb0-5714-4597-bc8b-cc521a978870",
+      "_toEntityKey": "d2ddbbb0-5714-4597-bc8b-cc521a978870",
+      "_type": "kube_cluster_contains_pod_security_policy",
+      "displayName": "CONTAINS",
+    },
+  ],
+  "encounteredTypes": Array [
+    "kube_cluster",
+    "kube_pod_security_policy",
+    "kube_cluster_contains_pod_security_policy",
+  ],
+  "numCollectedEntities": 2,
+  "numCollectedRelationships": 1,
+}
+`;

--- a/src/steps/policies/converters.ts
+++ b/src/steps/policies/converters.ts
@@ -1,0 +1,74 @@
+import {
+  createIntegrationEntity,
+  parseTimePropertyValue,
+} from '@jupiterone/integration-sdk-core';
+import * as k8s from '@kubernetes/client-node';
+import { Entities } from '../constants';
+
+export function createPodSecurityPolicyEntity(
+  data: k8s.V1beta1PodSecurityPolicy,
+) {
+  return createIntegrationEntity({
+    entityData: {
+      source: data,
+      assign: {
+        _class: Entities.POD_SECURITY_POLICY._class,
+        _type: Entities.POD_SECURITY_POLICY._type,
+        // metadata properties
+        _key: data.metadata?.uid,
+        name: data.metadata?.name,
+        displayName: data.metadata?.name,
+        generation: data.metadata?.generation,
+        deletionGracePeriodSeconds: data.metadata?.deletionGracePeriodSeconds,
+        resourceVersion: data.metadata?.resourceVersion,
+        createdOn: parseTimePropertyValue(data.metadata?.creationTimestamp),
+        // spec
+        // 5.2.5 Minimize the admission of containers with allowPrivilegeEscalation (Automated)
+        allowPrivilegeEscalation: data.spec?.allowPrivilegeEscalation === true,
+        // 5.2.8 Minimize the admission of containers with added capabilities (Automated)
+        allowedCapabilities: data.spec?.allowedCapabilities,
+        allowedProcMountTypes: data.spec?.allowedProcMountTypes,
+        allowedUnsafeSysctls: data.spec?.allowedUnsafeSysctls,
+        defaultAddCapabilities: data.spec?.defaultAddCapabilities,
+        defaultAllowPrivilegeEscalation:
+          data.spec?.defaultAllowPrivilegeEscalation,
+        forbiddenSysctls: data.spec?.forbiddenSysctls,
+        // 5.2.3 Minimize the admission of containers wishing to share the host IPC namespace (Automated)
+        hostIPC: data.spec?.hostIPC === true,
+        // 5.2.4 Minimize the admission of containers wishing to share the host network namespace (Automated)
+        hostNetwork: data.spec?.hostNetwork === true,
+        // 5.2.2 Minimize the admission of containers wishing to share the host process ID namespace (Automated)
+        hostPID: data.spec?.hostPID === true,
+        // 5.2.1 Minimize the admission of privileged containers (Automated)
+        privileged: data.spec?.privileged === true,
+        readOnlyRootFilesystem: data.spec?.readOnlyRootFilesystem === true,
+        // 5.2.7 Minimize the admission of containers with the NET_RAW capability (Automated)
+        // 5.2.9 Minimize the admission of containers with capabilities assigned (Manual)
+        requiredDropCapabilities: data.spec?.requiredDropCapabilities,
+        'runAsGroup.range': data.spec?.runAsGroup?.ranges?.map(
+          (range) => `${range.min}, ${range.max}`,
+        ),
+        'runAsGroup.rule': data.spec?.runAsGroup?.rule,
+        'runAsUser.range': data.spec?.runAsUser?.ranges?.map(
+          (range) => `${range.min}, ${range.max}`,
+        ),
+        // 5.2.6 Minimize the admission of root containers (Automated)
+        'runAsUser.rule': data.spec?.runAsUser?.rule,
+        'runtimeClass.allowedRuntimeClassNames':
+          data.spec?.runtimeClass?.allowedRuntimeClassNames,
+        'runtimeClass.defaultRuntimeClassName':
+          data.spec?.runtimeClass?.defaultRuntimeClassName,
+        'seLinux.rule': data.spec?.seLinux.rule,
+        'seLinux.seLinuxOptions.level':
+          data.spec?.seLinux.seLinuxOptions?.level,
+        'seLinux.seLinuxOptions.role': data.spec?.seLinux.seLinuxOptions?.role,
+        'seLinux.seLinuxOptions.type': data.spec?.seLinux.seLinuxOptions?.type,
+        'seLinux.seLinuxOptions.user': data.spec?.seLinux.seLinuxOptions?.user,
+        'supplementalGroups.range': data.spec?.supplementalGroups.ranges?.map(
+          (range) => `${range.min}, ${range.max}`,
+        ),
+        'supplementalGroups.rule': data.spec?.supplementalGroups?.rule,
+      },
+    },
+  });
+}

--- a/src/steps/policies/index.test.ts
+++ b/src/steps/policies/index.test.ts
@@ -1,0 +1,105 @@
+import { fetchPodSecurityPolicies } from '.';
+import { createDataCollectionTest } from '../../../test/recording';
+import { integrationConfig } from '../../../test/config';
+import { Entities, Relationships } from '../constants';
+import { fetchClusterDetails } from '../clusters';
+import { RelationshipClass } from '@jupiterone/data-model';
+
+describe('#fetchPodSecurityPolicies', () => {
+  test('should collect data', async () => {
+    await createDataCollectionTest({
+      recordingName: 'fetchPodSecurityPolicies',
+      recordingDirectory: __dirname,
+      integrationConfig,
+      stepFunctions: [fetchClusterDetails, fetchPodSecurityPolicies],
+      entitySchemaMatchers: [
+        {
+          _type: Entities.POD_SECURITY_POLICY._type,
+          matcher: {
+            _class: ['Configuration'],
+            schema: {
+              additionalProperties: false,
+              properties: {
+                _type: { const: 'kube_pod_security_policy' },
+                _rawData: {
+                  type: 'array',
+                  items: { type: 'object' },
+                },
+                name: { type: 'string' },
+                displayName: { type: 'string' },
+                generation: { type: 'number' },
+                deletionGracePeriodSeconds: { type: 'string' },
+                resourceVersion: { type: 'string' },
+                createdOn: { type: 'number' },
+
+                allowPrivilegeEscalation: { type: 'boolean' },
+                allowedCapabilities: {
+                  type: 'array',
+                  items: { type: 'string' },
+                },
+                allowedProcMountTypes: {
+                  type: 'array',
+                  items: { type: 'string' },
+                },
+                allowedUnsafeSysctls: {
+                  type: 'array',
+                  items: { type: 'string' },
+                },
+                defaultAddCapabilities: {
+                  type: 'array',
+                  items: { type: 'string' },
+                },
+                defaultAllowPrivilegeEscalation: { type: 'boolean' },
+                forbiddenSysctls: { type: 'array', items: { type: 'string' } },
+                hostIPC: { type: 'boolean' },
+                hostNetwork: { type: 'boolean' },
+                hostPID: { type: 'boolean' },
+                privileged: { type: 'boolean' },
+                readOnlyRootFilesystem: { type: 'boolean' },
+                requiredDropCapabilities: {
+                  type: 'array',
+                  items: { type: 'string' },
+                },
+                'runAsGroup.range': {
+                  type: 'array',
+                  items: { type: 'string' },
+                },
+                'runAsGroup.rule': { type: 'string' },
+                'runAsUser.range': { type: 'array', items: { type: 'string' } },
+                'runAsUser.rule': { type: 'string' },
+                'runtimeClass.allowedRuntimeClassNames': {
+                  type: 'array',
+                  items: { type: 'string' },
+                },
+                'runtimeClass.defaultRuntimeClassName': { type: 'string' },
+                'seLinux.rule': { type: 'string' },
+                'seLinux.seLinuxOptions.level': { type: 'string' },
+                'seLinux.seLinuxOptions.role': { type: 'string' },
+                'seLinux.seLinuxOptions.type': { type: 'string' },
+                'seLinux.seLinuxOptions.user': { type: 'string' },
+                'supplementalGroups.range': {
+                  type: 'array',
+                  items: { type: 'string' },
+                },
+                'supplementalGroups.rule': { type: 'string' },
+              },
+            },
+          },
+        },
+      ],
+      relationshipSchemaMatchers: [
+        {
+          _type: Relationships.CLUSTER_CONTAINS_POD_SECURITY_POLICY._type,
+          matcher: {
+            schema: {
+              properties: {
+                _class: { const: RelationshipClass.CONTAINS },
+                _type: { const: 'kube_cluster_contains_pod_security_policy' },
+              },
+            },
+          },
+        },
+      ],
+    });
+  });
+});

--- a/src/steps/policies/index.ts
+++ b/src/steps/policies/index.ts
@@ -1,0 +1,51 @@
+import {
+  createDirectRelationship,
+  RelationshipClass,
+  IntegrationStep,
+  Entity,
+} from '@jupiterone/integration-sdk-core';
+import { IntegrationConfig, IntegrationStepContext } from '../../config';
+import {
+  CLUSTER_ENTITY_DATA_KEY,
+  Entities,
+  IntegrationSteps,
+  Relationships,
+} from '../constants';
+import { PolicyClient } from '../../kubernetes/clients/policy';
+import { createPodSecurityPolicyEntity } from './converters';
+
+export async function fetchPodSecurityPolicies(
+  context: IntegrationStepContext,
+): Promise<void> {
+  const { instance, jobState } = context;
+  const { config } = instance;
+
+  const client = new PolicyClient(config);
+
+  const clusterEntity = (await jobState.getData(
+    CLUSTER_ENTITY_DATA_KEY,
+  )) as Entity;
+
+  await client.iteratePodSecurityPolicies(async (podSecurityPolicy) => {
+    const pspEntity = createPodSecurityPolicyEntity(podSecurityPolicy);
+    await jobState.addEntity(pspEntity);
+    await jobState.addRelationship(
+      createDirectRelationship({
+        _class: RelationshipClass.CONTAINS,
+        from: clusterEntity,
+        to: pspEntity,
+      }),
+    );
+  });
+}
+
+export const policiesSteps: IntegrationStep<IntegrationConfig>[] = [
+  {
+    id: IntegrationSteps.POD_SECURITY_POLICIES,
+    name: 'Fetch Pod Security Policies',
+    entities: [Entities.POD_SECURITY_POLICY],
+    relationships: [Relationships.CLUSTER_CONTAINS_POD_SECURITY_POLICY],
+    dependsOn: [IntegrationSteps.CLUSTERS],
+    executionHandler: fetchPodSecurityPolicies,
+  },
+];


### PR DESCRIPTION
This PR adds the coverage for the following benchmarks:

- 5.2.1 Minimize the admission of privileged containers (Automated)
- 5.2.2 Minimize the admission of containers wishing to share the host process ID namespace (Automated)
- 5.2.3 Minimize the admission of containers wishing to share the host IPC namespace (Automated)
- 5.2.4 Minimize the admission of containers wishing to share the host network namespace (Automated)
- 5.2.5 Minimize the admission of containers with allowPrivilegeEscalation (Automated)
- 5.2.6 Minimize the admission of root containers (Automated)
- 5.2.7 Minimize the admission of containers with the NET_RAW capability (Automated)
- 5.2.8 Minimize the admission of containers with added capabilities (Automated)
- 5.2.9 Minimize the admission of containers with capabilities assigned (Manual)

Ingested/relevant entities:
- **Kubernetes Pod Security Policy** `{ type: 'kube_pod_security_policy', class: 'Configuration' }`

Relationships:
- `kube_cluster` -> **CONTAINS** -> `kube_pod_security_policy`

![image](https://user-images.githubusercontent.com/8009142/139728695-8cf37c6f-5412-428e-a3ec-03c869dab0b0.png)

**Some notes:**
1) Some properties (`runAsGroup.range`, `runAsUser.range`, `supplementalGroups.range`) require some custom mapping, there's one idea implemented but it might now work for us.
2) Some J1QL questions below have a bit of pseudocode in them - they might require some trickery - please take a look at them too.

### J1QL Queries
- 5.2.1 Minimize the admission of privileged containers (Automated)
```
# GOOD CASE
Find kube_pod_security_policy with privileged != true 
   
# BAD CASE
Find kube_pod_security_policy with privileged = true
```
- 5.2.2 Minimize the admission of containers wishing to share the host process ID namespace (Automated)
```
# GOOD CASE
Find kube_pod_security_policy with hostPID != true
   
# BAD CASE
Find kube_pod_security_policy with hostPID = true
```

- 5.2.3 Minimize the admission of containers wishing to share the host IPC namespace (Automated)
```
# GOOD CASE
Find kube_pod_security_policy with hostIPC != true
   
# BAD CASE
Find kube_pod_security_policy with hostIPC = true
```

- 5.2.4 Minimize the admission of containers wishing to share the host network namespace (Automated)
```
# GOOD CASE
Find kube_pod_security_policy with hostNetwork != true
   
# BAD CASE
Find kube_pod_security_policy with hostNetwork = true
```

- 5.2.5 Minimize the admission of containers with allowPrivilegeEscalation (Automated)
```
# GOOD CASE
Find kube_pod_security_policy with allowPrivilegeEscalation != true
   
# BAD CASE
Find kube_pod_security_policy with allowPrivilegeEscalation = true
```

- 5.2.6 Minimize the admission of root containers (Automated)
```
# GOOD CASE
Find kube_pod_security_policy with runAsUser.rule = "MustRunAsNonRoot" or (with runAsUser.rule = "MustRunAs" and
runAsUser.range "not including 0")

# BAD CASE
Find kube_pod_security_policy with runAsUser.rule != "MustRunAsNonRoot" or (with runAsUser.rule = "MustRunAs" and
runAsUser.range "including 0")
```

- 5.2.7 Minimize the admission of containers with the NET_RAW capability (Automated)
```
# GOOD CASE
Find kube_pod_security_policy with requiredDropCapabilities "this array includes "NET_RAW" or "ALL""
   
# BAD CASE
Find kube_pod_security_policy with requiredDropCapabilities "this array doesn't include "NET_RAW" or "ALL""
```

- 5.2.8 Minimize the admission of containers with added capabilities (Automated)
```
# GOOD CASE
Find kube_pod_security_policy with allowedCapabilities = undefined
   
# BAD CASE
Find kube_pod_security_policy with allowedCapabilities != undefined
```

- 5.2.9 Minimize the admission of containers with capabilities assigned (Manual)
```
# GOOD CASE
Find kube_pod_security_policy with requiredDropCapabilities (might require manual review based on benchmark description)
   
# BAD CASE
Find kube_pod_security_policy with requiredDropCapabilities (might require manual review based on benchmark description)
```

Pinging @austinkelleher 
