### PR TITLE
fixing package.json to use peerDependencies for integration-sdk-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,12 @@
     "@jupiterone/integration-sdk-testing": "^7.4.0"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-core": "^7.4.0",
     "@jupiterone/integration-sdk-dev-tools": "^7.4.0",
     "@kubernetes/client-node": "^0.14.3",
     "node-fetch": "2.6.1"
+  },
+  "peerDependencies": {
+    "@jupiterone/integration-sdk-core": "^7.4.0"
   }
+
 }


### PR DESCRIPTION
Fixing package.json to use peerDependencies for integration-sdk-core to avoid exception thrown to Sentry.
