### PR TITLE
INT-2265 - Fix `kube_container_spec` *USES* `kube_volume` duplicate `_key`

### DIFF
--- a/src/steps/deployments/__snapshots__/converters.test.ts.snap
+++ b/src/steps/deployments/__snapshots__/converters.test.ts.snap
@@ -1,5 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`#createContainerSpecToVolumeRelationship should generate relationship with mountPath 1`] = `
+Object {
+  "_class": "USES",
+  "_fromEntityKey": "12345/coredns",
+  "_key": "12345/coredns|uses|12345/config-volume/mount_config-volume/mount_path_/etc/coredns",
+  "_toEntityKey": "12345/config-volume",
+  "_type": "kube_container_spec_uses_volume",
+  "displayName": "USES",
+  "mountPath": "/etc/coredns",
+  "mountPropagation": undefined,
+  "readOnly": true,
+  "subPath": undefined,
+}
+`;
+
+exports[`#createContainerSpecToVolumeRelationship should generate relationship with mountPath and subPath 1`] = `
+Object {
+  "_class": "USES",
+  "_fromEntityKey": "12345/coredns",
+  "_key": "12345/coredns|uses|12345/config-volume/mount_config-volume/mount_path_/etc/coredns/mount_sub_path_abc",
+  "_toEntityKey": "12345/config-volume",
+  "_type": "kube_container_spec_uses_volume",
+  "displayName": "USES",
+  "mountPath": "/etc/coredns",
+  "mountPropagation": undefined,
+  "readOnly": true,
+  "subPath": "abc",
+}
+`;
+
+exports[`#createContainerSpecToVolumeRelationship should generate relationship without mountPath 1`] = `
+Object {
+  "_class": "USES",
+  "_fromEntityKey": "12345/coredns",
+  "_key": "12345/coredns|uses|12345/config-volume/mount_config-volume",
+  "_toEntityKey": "12345/config-volume",
+  "_type": "kube_container_spec_uses_volume",
+  "displayName": "USES",
+  "mountPath": undefined,
+  "mountPropagation": undefined,
+  "readOnly": true,
+  "subPath": undefined,
+}
+`;
+
 exports[`#createDeploymentEntity should convert data 1`] = `
 Object {
   "_class": Array [

--- a/src/steps/deployments/__snapshots__/index.test.ts.snap
+++ b/src/steps/deployments/__snapshots__/index.test.ts.snap
@@ -2107,7 +2107,7 @@ Object {
     Object {
       "_class": "USES",
       "_fromEntityKey": "0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/socket-mount",
-      "_key": "0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/socket-mount|uses|0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/docker-sock",
+      "_key": "0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/socket-mount|uses|0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/docker-sock/mount_docker-sock/mount_path_/var/run/docker.sock",
       "_toEntityKey": "0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/docker-sock",
       "_type": "kube_container_spec_uses_volume",
       "displayName": "USES",
@@ -2119,7 +2119,7 @@ Object {
     Object {
       "_class": "USES",
       "_fromEntityKey": "0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/socket-mount",
-      "_key": "0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/socket-mount|uses|0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/docker-directory",
+      "_key": "0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/socket-mount|uses|0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/docker-directory/mount_docker-directory/mount_path_/var/lib/docker",
       "_toEntityKey": "0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/docker-directory",
       "_type": "kube_container_spec_uses_volume",
       "displayName": "USES",
@@ -2147,7 +2147,7 @@ Object {
     Object {
       "_class": "USES",
       "_fromEntityKey": "664fec78-0d67-4bbd-a02d-ad978500e342/coredns",
-      "_key": "664fec78-0d67-4bbd-a02d-ad978500e342/coredns|uses|664fec78-0d67-4bbd-a02d-ad978500e342/config-volume",
+      "_key": "664fec78-0d67-4bbd-a02d-ad978500e342/coredns|uses|664fec78-0d67-4bbd-a02d-ad978500e342/config-volume/mount_config-volume/mount_path_/etc/coredns",
       "_toEntityKey": "664fec78-0d67-4bbd-a02d-ad978500e342/config-volume",
       "_type": "kube_container_spec_uses_volume",
       "displayName": "USES",

--- a/src/steps/deployments/converters.test.ts
+++ b/src/steps/deployments/converters.test.ts
@@ -1,8 +1,69 @@
-import { createDeploymentEntity } from './converters';
-import { createMockDeployment } from '../../../test/mocks';
+import {
+  createContainerSpecEntity,
+  createContainerSpecToVolumeRelationship,
+  createDeploymentEntity,
+  createVolumeEntity,
+} from './converters';
+import {
+  createMockContainer,
+  createMockDeployment,
+  createMockVolume,
+  createMockVolumeMount,
+} from '../../../test/mocks';
 
 describe('#createDeploymentEntity', () => {
   test('should convert data', () => {
     expect(createDeploymentEntity(createMockDeployment())).toMatchSnapshot();
+  });
+});
+
+describe('#createContainerSpecToVolumeRelationship', () => {
+  test('should generate relationship with mountPath', () => {
+    const deploymentId = '12345';
+
+    expect(
+      createContainerSpecToVolumeRelationship({
+        containerSpecEntity: createContainerSpecEntity(
+          deploymentId,
+          createMockContainer(),
+        ),
+        volumeEntity: createVolumeEntity(deploymentId, createMockVolume()),
+        volumeMount: createMockVolumeMount(),
+      }),
+    ).toMatchSnapshot();
+  });
+
+  test('should generate relationship without mountPath', () => {
+    const deploymentId = '12345';
+
+    expect(
+      createContainerSpecToVolumeRelationship({
+        containerSpecEntity: createContainerSpecEntity(
+          deploymentId,
+          createMockContainer(),
+        ),
+        volumeEntity: createVolumeEntity(deploymentId, createMockVolume()),
+        volumeMount: createMockVolumeMount({
+          mountPath: undefined,
+        }),
+      }),
+    ).toMatchSnapshot();
+  });
+
+  test('should generate relationship with mountPath and subPath', () => {
+    const deploymentId = '12345';
+
+    expect(
+      createContainerSpecToVolumeRelationship({
+        containerSpecEntity: createContainerSpecEntity(
+          deploymentId,
+          createMockContainer(),
+        ),
+        volumeEntity: createVolumeEntity(deploymentId, createMockVolume()),
+        volumeMount: createMockVolumeMount({
+          subPath: 'abc',
+        }),
+      }),
+    ).toMatchSnapshot();
   });
 });

--- a/src/steps/replica-sets/__snapshots__/index.test.ts.snap
+++ b/src/steps/replica-sets/__snapshots__/index.test.ts.snap
@@ -3519,7 +3519,7 @@ Object {
     Object {
       "_class": "USES",
       "_fromEntityKey": "0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/socket-mount",
-      "_key": "0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/socket-mount|uses|0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/docker-sock",
+      "_key": "0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/socket-mount|uses|0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/docker-sock/mount_docker-sock/mount_path_/var/run/docker.sock",
       "_toEntityKey": "0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/docker-sock",
       "_type": "kube_container_spec_uses_volume",
       "displayName": "USES",
@@ -3531,7 +3531,7 @@ Object {
     Object {
       "_class": "USES",
       "_fromEntityKey": "0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/socket-mount",
-      "_key": "0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/socket-mount|uses|0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/docker-directory",
+      "_key": "0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/socket-mount|uses|0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/docker-directory/mount_docker-directory/mount_path_/var/lib/docker",
       "_toEntityKey": "0ffd1ce8-e97e-4bc8-a2d6-075fe64488e3/docker-directory",
       "_type": "kube_container_spec_uses_volume",
       "displayName": "USES",
@@ -3559,7 +3559,7 @@ Object {
     Object {
       "_class": "USES",
       "_fromEntityKey": "664fec78-0d67-4bbd-a02d-ad978500e342/coredns",
-      "_key": "664fec78-0d67-4bbd-a02d-ad978500e342/coredns|uses|664fec78-0d67-4bbd-a02d-ad978500e342/config-volume",
+      "_key": "664fec78-0d67-4bbd-a02d-ad978500e342/coredns|uses|664fec78-0d67-4bbd-a02d-ad978500e342/config-volume/mount_config-volume/mount_path_/etc/coredns",
       "_toEntityKey": "664fec78-0d67-4bbd-a02d-ad978500e342/config-volume",
       "_type": "kube_container_spec_uses_volume",
       "displayName": "USES",


### PR DESCRIPTION
There can be multiple relationships between `kube_container_spec` and
`kube_volume`. The uniqueness of these relationships is determined by
the volume mount path, volume mount sub path, and the volume name, and
the `_key` of the relationship has been updated to reflect this.