### PR TITLE
INT-2297 - Ingest Kubernetes Users

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -215,6 +215,7 @@ The following entities are created:
 | Kubernetes Service              | `kube_service`              | `Service`       |
 | Kubernetes Service Account      | `kube_service_account`      | `User`          |
 | Kubernetes StatefulSet          | `kube_stateful_set`         | `Deployment`    |
+| Kubernetes User                 | `kube_user`                 | `User`          |
 | Kubernetes Volume               | `kube_volume`               | `Disk`          |
 
 ### Relationships

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -66,6 +66,9 @@ export default async function getStepStartStates(
       [IntegrationSteps.SERVICE_ACCOUNTS]: {
         disabled: false,
       },
+      [IntegrationSteps.USERS]: {
+        disabled: false,
+      },
       [IntegrationSteps.ROLES]: {
         disabled: false,
       },

--- a/src/kubernetes/clients/core.ts
+++ b/src/kubernetes/clients/core.ts
@@ -206,4 +206,12 @@ export class CoreClient extends Client {
       },
     );
   }
+
+  async iterateUsers(
+    callback: (data: k8s.V1beta1UserSubject) => Promise<void>,
+  ): Promise<void> {
+    for (const user of this.kubeConfig.users || []) {
+      await callback(user);
+    }
+  }
 }

--- a/src/steps/constants.ts
+++ b/src/steps/constants.ts
@@ -10,6 +10,7 @@ export enum IntegrationSteps {
   NETWORK_POLICIES = 'fetch-network-policies',
   POD_SECURITY_POLICIES = 'fetch-pod-security-policies',
   SERVICE_ACCOUNTS = 'fetch-service-accounts',
+  USERS = 'fetch-users',
   ROLES = 'fetch-roles',
   CLUSTER_ROLES = 'fetch-cluster-roles',
   ROLE_BINDINGS = 'fetch-role-bindings',
@@ -37,6 +38,7 @@ export const Entities: Record<
   | 'NETWORK_POLICY'
   | 'POD_SECURITY_POLICY'
   | 'SERVICE_ACCOUNT'
+  | 'USER'
   | 'ROLE'
   | 'CLUSTER_ROLE'
   | 'ROLE_BINDING'
@@ -75,6 +77,11 @@ export const Entities: Record<
     _type: 'kube_service_account',
     _class: ['User'],
     resourceName: 'Kubernetes Service Account',
+  },
+  USER: {
+    _type: 'kube_user',
+    _class: ['User'],
+    resourceName: 'Kubernetes User',
   },
   ROLE: {
     _type: 'kube_role',

--- a/src/steps/subjects/__snapshots__/converters.test.ts.snap
+++ b/src/steps/subjects/__snapshots__/converters.test.ts.snap
@@ -30,3 +30,29 @@ Object {
   "username": "ttl-controller",
 }
 `;
+
+exports[`#createUserEntity should convert data 1`] = `
+Object {
+  "_class": Array [
+    "User",
+  ],
+  "_key": "kube_user:my-name",
+  "_rawData": Array [
+    Object {
+      "name": "default",
+      "rawData": Object {
+        "certFile": "/some/path/client.crt",
+        "keyFile": "/some/path/client.key",
+        "name": "my-name",
+        "username": "my-username",
+      },
+    },
+  ],
+  "_type": "kube_user",
+  "certFile": "/some/path/client.crt",
+  "displayName": "my-name",
+  "keyFile": "/some/path/client.key",
+  "name": "my-name",
+  "username": "my-username",
+}
+`;

--- a/src/steps/subjects/__snapshots__/index.test.ts.snap
+++ b/src/steps/subjects/__snapshots__/index.test.ts.snap
@@ -2759,3 +2759,39 @@ Object {
   "numCollectedRelationships": 39,
 }
 `;
+
+exports[`#fetchUsers should collect data: jobState 1`] = `
+Object {
+  "collectedEntities": Array [
+    Object {
+      "_class": Array [
+        "User",
+      ],
+      "_key": "kube_user:docker-desktop",
+      "_rawData": Array [
+        Object {
+          "name": "default",
+          "rawData": Object {
+            "certFile": undefined,
+            "keyFile": undefined,
+            "name": "docker-desktop",
+            "username": undefined,
+          },
+        },
+      ],
+      "_type": "kube_user",
+      "certFile": undefined,
+      "displayName": "docker-desktop",
+      "keyFile": undefined,
+      "name": "docker-desktop",
+      "username": "docker-desktop",
+    },
+  ],
+  "collectedRelationships": Array [],
+  "encounteredTypes": Array [
+    "kube_user",
+  ],
+  "numCollectedEntities": 1,
+  "numCollectedRelationships": 0,
+}
+`;

--- a/src/steps/subjects/converters.test.ts
+++ b/src/steps/subjects/converters.test.ts
@@ -1,10 +1,20 @@
-import { createServiceAccountEntity } from './converters';
-import { createMockServiceAccount } from '../../../test/mocks';
+import {
+  createServiceAccountEntity,
+  createUserEntity,
+  UserSubject,
+} from './converters';
+import { createMockServiceAccount, createMockUser } from '../../../test/mocks';
 
 describe('#createServiceAccountEntity', () => {
   test('should convert data', () => {
     expect(
       createServiceAccountEntity(createMockServiceAccount()),
     ).toMatchSnapshot();
+  });
+});
+
+describe('#createUserEntity', () => {
+  test('should convert data', () => {
+    expect(createUserEntity(createMockUser() as UserSubject)).toMatchSnapshot();
   });
 });

--- a/src/steps/subjects/converters.ts
+++ b/src/steps/subjects/converters.ts
@@ -1,5 +1,6 @@
 import {
   createIntegrationEntity,
+  Entity,
   parseTimePropertyValue,
 } from '@jupiterone/integration-sdk-core';
 import * as k8s from '@kubernetes/client-node';
@@ -23,4 +24,34 @@ export function createServiceAccountEntity(data: k8s.V1ServiceAccount) {
       },
     },
   });
+}
+
+export type UserSubject = k8s.V1beta1UserSubject & {
+  username?: string;
+  certFile?: string;
+  keyFile?: string;
+};
+
+export function createUserEntity(data: UserSubject): Entity {
+  return {
+    _class: Entities.USER._class,
+    _rawData: [
+      {
+        name: 'default',
+        rawData: {
+          name: data.name,
+          username: data.username,
+          certFile: data.certFile,
+          keyFile: data.keyFile,
+        },
+      },
+    ],
+    _type: Entities.USER._type,
+    _key: `kube_user:${data.name}`,
+    name: data.name,
+    username: data.username || data.name,
+    displayName: data.name,
+    certFile: data.certFile,
+    keyFile: data.keyFile,
+  };
 }

--- a/src/steps/subjects/index.test.ts
+++ b/src/steps/subjects/index.test.ts
@@ -1,4 +1,4 @@
-import { fetchServiceAccounts } from '.';
+import { fetchServiceAccounts, fetchUsers } from '.';
 import { createDataCollectionTest } from '../../../test/recording';
 import { integrationConfig } from '../../../test/config';
 import { Entities, Relationships } from '../constants';
@@ -45,6 +45,40 @@ describe('#fetchServiceAccounts', () => {
               properties: {
                 _class: { const: RelationshipClass.CONTAINS },
                 _type: { const: 'kube_namespace_contains_service_account' },
+              },
+            },
+          },
+        },
+      ],
+    });
+  });
+});
+
+describe('#fetchUsers', () => {
+  test('should collect data', async () => {
+    await createDataCollectionTest({
+      recordingName: 'fetchUsers',
+      recordingDirectory: __dirname,
+      integrationConfig,
+      stepFunctions: [fetchUsers],
+      entitySchemaMatchers: [
+        {
+          _type: Entities.USER._type,
+          matcher: {
+            _class: ['User'],
+            schema: {
+              additionalProperties: false,
+              properties: {
+                _type: { const: 'kube_user' },
+                _rawData: {
+                  type: 'array',
+                  items: { type: 'object' },
+                },
+                name: { type: 'string' },
+                username: { type: 'string' },
+                displayName: { type: 'string' },
+                certFile: { type: 'string' },
+                keyFile: { type: 'string' },
               },
             },
           },

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -1,5 +1,6 @@
 import * as k8s from '@kubernetes/client-node';
 import { V1Container, V1Volume, V1VolumeMount } from '@kubernetes/client-node';
+import { UserSubject } from '../src/steps/subjects/converters';
 
 export function createMockNamespace(): Partial<k8s.V1Namespace> {
   return {
@@ -204,6 +205,15 @@ export function createMockServiceAccount(): Partial<k8s.V1ServiceAccount> {
       resourceVersion: '236',
       uid: 'a9e0bedc-2bcf-4fe2-9414-5fe1d03121c6',
     },
+  };
+}
+
+export function createMockUser(): Partial<UserSubject> {
+  return {
+    name: 'my-name',
+    username: 'my-username',
+    certFile: '/some/path/client.crt',
+    keyFile: '/some/path/client.key',
   };
 }
 


### PR DESCRIPTION
A very small PR that just ingests Kubernetes users. They're a bit different as they aren't represented inside of Kubernetes as K8s entities/resources so we have to get them from the `kube config` file.

Having users be ingested will allow us to add roles/bindings relationships. 