### PR TITLE
INT-5393 - Switch direct relationships to mapped relationships

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -228,8 +228,6 @@ The following relationships are created:
 | `kube_cluster`        | **CONTAINS**          | `kube_cluster_role_binding` |
 | `kube_cluster`        | **CONTAINS**          | `kube_namespace`            |
 | `kube_cluster`        | **CONTAINS**          | `kube_pod_security_policy`  |
-| `kube_cluster`        | **IS**                | `azure_kubernetes_cluster`  |
-| `kube_cluster`        | **IS**                | `google_container_cluster`  |
 | `kube_container_spec` | **USES**              | `kube_volume`               |
 | `kube_cron_job`       | **MANAGES**           | `kube_job`                  |
 | `kube_deployment`     | **MANAGES**           | `kube_replica_set`          |
@@ -247,6 +245,15 @@ The following relationships are created:
 | `kube_namespace`      | **CONTAINS**          | `kube_service`              |
 | `kube_namespace`      | **CONTAINS**          | `kube_service_account`      |
 | `kube_namespace`      | **CONTAINS**          | `kube_stateful_set`         |
+
+### Mapped Relationships
+
+The following mapped relationships are created:
+
+| Source Entity `_type` | Relationship `_class` | Target Entity `_type`        | Direction |
+| --------------------- | --------------------- | ---------------------------- | --------- |
+| `kube_cluster`        | **IS**                | `*azure_kubernetes_cluster*` | FORWARD   |
+| `kube_cluster`        | **IS**                | `*google_container_cluster*` | FORWARD   |
 
 <!--
 ********************************************************************************

--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
     "prepack": "yarn build"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-testing": "^8.22.2"
+    "@jupiterone/integration-sdk-testing": "^8.22.6"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk-dev-tools": "^8.22.2",
+    "@jupiterone/integration-sdk-dev-tools": "^8.22.6",
     "@kubernetes/client-node": "^0.14.3",
     "node-fetch": "2.6.1"
   },
   "peerDependencies": {
-    "@jupiterone/integration-sdk-core": "^8.22.2"
+    "@jupiterone/integration-sdk-core": "^8.22.6"
   }
 }

--- a/src/steps/clusters/index.test.ts
+++ b/src/steps/clusters/index.test.ts
@@ -6,7 +6,7 @@ import {
 } from '.';
 import { createDataCollectionTest } from '../../../test/recording';
 import { integrationConfig } from '../../../test/config';
-import { Entities, Relationships } from '../constants';
+import { Entities, MappedRelationships, Relationships } from '../constants';
 import { fetchNamespaces } from '../namespaces';
 import { RelationshipClass } from '@jupiterone/data-model';
 import { fetchConfigMaps } from '../config-maps';
@@ -85,7 +85,7 @@ describe('#buildClusterAksRelationships', () => {
       entitySchemaMatchers: [],
       relationshipSchemaMatchers: [
         {
-          _type: Relationships.CLUSTER_IS_AKS_CLUSTER._type,
+          _type: MappedRelationships.CLUSTER_IS_AKS_CLUSTER._type,
           matcher: {
             schema: {
               properties: {
@@ -110,7 +110,7 @@ describe('#buildClusterGkeRelationships', () => {
       entitySchemaMatchers: [],
       relationshipSchemaMatchers: [
         {
-          _type: Relationships.CLUSTER_IS_GKE_CLUSTER._type,
+          _type: MappedRelationships.CLUSTER_IS_GKE_CLUSTER._type,
           matcher: {
             schema: {
               properties: {

--- a/src/steps/clusters/index.ts
+++ b/src/steps/clusters/index.ts
@@ -13,6 +13,7 @@ import {
   CLUSTER_ENTITY_DATA_KEY,
   Entities,
   IntegrationSteps,
+  MappedRelationships,
   Relationships,
 } from '../constants';
 import { createClusterEntity } from './converters';
@@ -118,7 +119,7 @@ export async function buildClusterAksRelationships(
         await jobState.addRelationship(
           createMappedRelationship({
             _class: RelationshipClass.IS,
-            _type: Relationships.CLUSTER_IS_AKS_CLUSTER._type,
+            _type: MappedRelationships.CLUSTER_IS_AKS_CLUSTER._type,
             _mapping: {
               relationshipDirection: RelationshipDirection.FORWARD,
               sourceEntityKey: clusterEntity._key,
@@ -177,7 +178,7 @@ export async function buildClusterGkeRelationships(
     await jobState.addRelationship(
       createMappedRelationship({
         _class: RelationshipClass.IS,
-        _type: Relationships.CLUSTER_IS_GKE_CLUSTER._type,
+        _type: MappedRelationships.CLUSTER_IS_GKE_CLUSTER._type,
         _mapping: {
           relationshipDirection: RelationshipDirection.FORWARD,
           sourceEntityKey: clusterEntity._key,
@@ -214,7 +215,8 @@ export const clustersSteps: IntegrationStep<IntegrationConfig>[] = [
     id: IntegrationSteps.BUILD_CLUSTER_AKS_RELATIONSHIPS,
     name: 'Build Cluster AKS Relationships',
     entities: [],
-    relationships: [Relationships.CLUSTER_IS_AKS_CLUSTER],
+    relationships: [],
+    mappedRelationships: [MappedRelationships.CLUSTER_IS_AKS_CLUSTER],
     dependsOn: [IntegrationSteps.CLUSTERS, IntegrationSteps.CONFIGMAPS],
     executionHandler: buildClusterAksRelationships,
   },
@@ -222,7 +224,8 @@ export const clustersSteps: IntegrationStep<IntegrationConfig>[] = [
     id: IntegrationSteps.BUILD_CLUSTER_GKE_RELATIONSHIPS,
     name: 'Build Cluster GKE Relationships',
     entities: [],
-    relationships: [Relationships.CLUSTER_IS_GKE_CLUSTER],
+    relationships: [],
+    mappedRelationships: [MappedRelationships.CLUSTER_IS_GKE_CLUSTER],
     dependsOn: [IntegrationSteps.CLUSTERS],
     executionHandler: buildClusterGkeRelationships,
   },

--- a/src/steps/constants.ts
+++ b/src/steps/constants.ts
@@ -1,6 +1,8 @@
 import {
   RelationshipClass,
+  RelationshipDirection,
   StepEntityMetadata,
+  StepMappedRelationshipMetadata,
   StepRelationshipMetadata,
 } from '@jupiterone/integration-sdk-core';
 
@@ -200,8 +202,6 @@ export const Relationships: Record<
   | 'CLUSTER_CONTAINS_NAMESPACE'
   | 'CLUSTER_CONTAINS_CLUSTER_ROLE'
   | 'CLUSTER_CONTAINS_CLUSTER_ROLE_BINDING'
-  | 'CLUSTER_IS_AKS_CLUSTER'
-  | 'CLUSTER_IS_GKE_CLUSTER'
   | 'NAMESPACE_CONTAINS_POD'
   | 'NAMESPACE_CONTAINS_SERVICE'
   | 'NAMESPACE_CONTAINS_DEPLOYMENT'
@@ -250,18 +250,6 @@ export const Relationships: Record<
     _class: RelationshipClass.CONTAINS,
     sourceType: Entities.CLUSTER._type,
     targetType: Entities.CLUSTER_ROLE_BINDING._type,
-  },
-  CLUSTER_IS_AKS_CLUSTER: {
-    _type: 'kube_cluster_is_azure_kubernetes_cluster',
-    _class: RelationshipClass.IS,
-    sourceType: Entities.CLUSTER._type,
-    targetType: Entities.AZURE_KUBERNETES_CLUSTER._type,
-  },
-  CLUSTER_IS_GKE_CLUSTER: {
-    _type: 'kube_cluster_is_google_container_cluster',
-    _class: RelationshipClass.IS,
-    sourceType: Entities.CLUSTER._type,
-    targetType: Entities.GOOGLE_KUBERNETES_CLUSTER._type,
   },
   NAMESPACE_CONTAINS_POD: {
     _type: 'kube_namespace_contains_pod',
@@ -400,5 +388,25 @@ export const Relationships: Record<
     _class: RelationshipClass.CONTAINS,
     sourceType: Entities.POD._type,
     targetType: Entities.CONTAINER._type,
+  },
+};
+
+export const MappedRelationships: Record<
+  string,
+  StepMappedRelationshipMetadata
+> = {
+  CLUSTER_IS_AKS_CLUSTER: {
+    _type: 'kube_cluster_is_azure_kubernetes_cluster',
+    sourceType: Entities.CLUSTER._type,
+    targetType: Entities.AZURE_KUBERNETES_CLUSTER._type,
+    _class: RelationshipClass.IS,
+    direction: RelationshipDirection.FORWARD,
+  },
+  CLUSTER_IS_GKE_CLUSTER: {
+    _type: 'kube_cluster_is_google_container_cluster',
+    sourceType: Entities.CLUSTER._type,
+    targetType: Entities.GOOGLE_KUBERNETES_CLUSTER._type,
+    _class: RelationshipClass.IS,
+    direction: RelationshipDirection.FORWARD,
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -748,12 +748,12 @@
     ajv "^8.0.0"
     ajv-formats "^2.0.0"
 
-"@jupiterone/integration-sdk-cli@^8.22.2":
-  version "8.22.2"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-cli/-/integration-sdk-cli-8.22.2.tgz#45e21bc5dd0dc3dbbc0780e8bdfc133a1dc0e84c"
-  integrity sha512-eSaPT9UaP3c9mDbp31peJKdqf5FOzpDGLs0+da+y85hi5spm0+CMTtcUgQQqi5dgklDe1a4irVUeIZGaydWeQw==
+"@jupiterone/integration-sdk-cli@^8.22.6":
+  version "8.22.6"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-cli/-/integration-sdk-cli-8.22.6.tgz#f482a49e0072a9bc5d0fb3e3cfed76527c0f2cab"
+  integrity sha512-c9nkh8jswXCEP6AAorOCHSdoMhKB15iwd7/V5afP5Br5d7/yfJq9LwqIbr//xiSjJ3DILGxaj/Ee3fr+nxGUJA==
   dependencies:
-    "@jupiterone/integration-sdk-runtime" "^8.22.2"
+    "@jupiterone/integration-sdk-runtime" "^8.22.6"
     chalk "^4"
     commander "^5.0.0"
     fs-extra "^10.1.0"
@@ -767,22 +767,22 @@
     upath "^1.2.0"
     vis "^4.21.0-EOL"
 
-"@jupiterone/integration-sdk-core@^8.22.2":
-  version "8.22.2"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-8.22.2.tgz#b355e583374ffef0001891269788482d4f5eabcf"
-  integrity sha512-EmTTawsTThjYgnGYDstSXp6i87o/Hlr+hIT/zvPdWfYQBvGLbQ/SLNd6DaGlZjjpdxPvFlXHnkE8ZweOT/1JZg==
+"@jupiterone/integration-sdk-core@^8.22.6":
+  version "8.22.6"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-8.22.6.tgz#19ad891e1dc52c1aa6b48215557dde85f51ecf14"
+  integrity sha512-QKOQUd3bxQbzf5CCN/rn284MPxdL7NL1zg4GnWrGRTOEzcBhr1HzunFbzXEq0ceASjFQXQLKiFXhR5BuRyMb8Q==
   dependencies:
     "@jupiterone/data-model" "^0.51.0"
     lodash "^4.17.21"
     uuid "^8.3.2"
 
-"@jupiterone/integration-sdk-dev-tools@^8.22.2":
-  version "8.22.2"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-dev-tools/-/integration-sdk-dev-tools-8.22.2.tgz#2574b6fa7eb5dfa3d554b1c9914251ccd2f982bf"
-  integrity sha512-l6H3U9OkNA44rzYunnMB/IHCUSngHo6xq6wFyReRDp75xs/EjolbSaiFfaOQ8yF8zqIHYRlz4raMywQpeII4hw==
+"@jupiterone/integration-sdk-dev-tools@^8.22.6":
+  version "8.22.6"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-dev-tools/-/integration-sdk-dev-tools-8.22.6.tgz#59ba0d013f264afb924de16bc1835bb735aa6f79"
+  integrity sha512-fuDkrIAISoSqdF4Pz4S6hFDOSXNn3ppgHWsikCvwqkpKnPX7Tm0PVSVh9Wu57zcXeWyv6ku81oyfKpuhbD9xOg==
   dependencies:
-    "@jupiterone/integration-sdk-cli" "^8.22.2"
-    "@jupiterone/integration-sdk-testing" "^8.22.2"
+    "@jupiterone/integration-sdk-cli" "^8.22.6"
+    "@jupiterone/integration-sdk-testing" "^8.22.6"
     "@types/jest" "^27.1.0"
     "@types/node" "^14.0.5"
     "@typescript-eslint/eslint-plugin" "^4.22.0"
@@ -798,12 +798,12 @@
     ts-node "^9.1.1"
     typescript "^4.2.4"
 
-"@jupiterone/integration-sdk-runtime@^8.22.2":
-  version "8.22.2"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-runtime/-/integration-sdk-runtime-8.22.2.tgz#535ac36f993f9fc5be05fc4dad178a48d5160ad1"
-  integrity sha512-raZEfF6AWaVxp7UokqeJbp+xBj0X5fOWKE8gx5uew6jdN+HhqHMk1OvRSKc12vAHvP1mJLd8FQqCliEbw/Nnlg==
+"@jupiterone/integration-sdk-runtime@^8.22.6":
+  version "8.22.6"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-runtime/-/integration-sdk-runtime-8.22.6.tgz#99bb8e4e84b2f7179c5e9023b8c82bb0189cb888"
+  integrity sha512-jhjonUWpQYgGXv143pV+UzxlBto/dBZceXnM/YwGrFpbsjs8y642GG5tXsKd7RfKp/OSCnY08o8URVVJz4YApw==
   dependencies:
-    "@jupiterone/integration-sdk-core" "^8.22.2"
+    "@jupiterone/integration-sdk-core" "^8.22.6"
     "@lifeomic/alpha" "^1.4.0"
     "@lifeomic/attempt" "^3.0.3"
     async-sema "^3.1.0"
@@ -821,13 +821,13 @@
     rimraf "^3.0.2"
     uuid "^7.0.3"
 
-"@jupiterone/integration-sdk-testing@^8.22.2":
-  version "8.22.2"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-testing/-/integration-sdk-testing-8.22.2.tgz#fa2487ebbe7515f6dbe74e1a6d519faa8b614b87"
-  integrity sha512-mHZpH3kJc2m/R1dRt0Rfj9o5mzVg/6nCx2AlYnxX3TEC0Vr3R917a8KOCkg1tk46B/1ccyVToy+iCePJz58gbw==
+"@jupiterone/integration-sdk-testing@^8.22.6":
+  version "8.22.6"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-testing/-/integration-sdk-testing-8.22.6.tgz#37e7352217159da02e23f538d6a4243b767dfbfa"
+  integrity sha512-IRJtCgVdz+3wxEZg7NZinn/G3sLci/TZR+tmAp6EI+ZBwKVv1/X0VeROom4PVfI1qJGDp9cZkOztljqU4VyJ9w==
   dependencies:
-    "@jupiterone/integration-sdk-core" "^8.22.2"
-    "@jupiterone/integration-sdk-runtime" "^8.22.2"
+    "@jupiterone/integration-sdk-core" "^8.22.6"
+    "@jupiterone/integration-sdk-runtime" "^8.22.6"
     "@pollyjs/adapter-node-http" "^6.0.5"
     "@pollyjs/core" "^6.0.5"
     "@pollyjs/persister-fs" "^6.0.5"


### PR DESCRIPTION
Newer versions of the SDK support `mappedRelationships` to be
specified in the step metadata. The K8S integration can build
mapped relationships to `Cluster` entities in external systems.
These relationships should be marked as mapped relationships
instead of direct.